### PR TITLE
don't spawn nameplates if another addons are used

### DIFF
--- a/core/spawn.lua
+++ b/core/spawn.lua
@@ -129,7 +129,7 @@ if L.F.CreateBossStyle then
 end
 
 --spawn nameplates
-if L.F.CreateNamePlateStyle then
+if L.F.CreateNamePlateStyle and not IsAddOnLoaded("Plater") and not IsAddOnLoaded("TidyPlates") and not IsAddOnLoaded("Kui_Nameplates") then
   oUF:SetActiveStyle(A.."Nameplate")
   oUF:SpawnNamePlates(A, L.C.NamePlateCallback, L.C.NamePlateCVars)
 end


### PR DESCRIPTION
I've added check for some popular nameplate addons, otherwise i've got error.
Added plater, tidyplates, kui_nameplates