### PR TITLE
Update minimap.lua

### DIFF
--- a/modules/minimap.lua
+++ b/modules/minimap.lua
@@ -38,6 +38,9 @@ Minimap:SetMaskTexture(L.C.texture)
 Minimap:ClearAllPoints()
 Minimap:SetPoint("CENTER", -10, 25)
 Minimap:SetSize(210, 210)
+Minimap:SetArchBlobRingScalar( 0 )
+Minimap:SetQuestBlobRingScalar( 0 )
+function GetMinimapShape() return "SQUARE" end
 
 -- New minimap border
 local border = CreateFrame("Frame", nil, Minimap, BackdropTemplateMixin and "BackdropTemplate")


### PR DESCRIPTION
* Hides BlobRings on the MiniMap since it's round and doesn't fit the square style (all credit for that goes to [tonyleila](https://www.wowinterface.com/downloads/info22413-HideBlobRing.html) for turning a macro provided by saiket into an addon)
* use the user api defined [GetMinimapShape](https://wowpedia.fandom.com/wiki/GetMinimapShape) for proper minimap button positioning